### PR TITLE
Refine workflow-automation skill, disambiguate hubspot vs hs CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Install Skills](https://img.shields.io/badge/Install%20Skills-hubspot%2Fagent--cli--skills-blue)](https://skills.sh/hubspot/agent-cli-skills)
 
-Markdown skill files for AI agents (Claude Code, Cursor, Windsurf, and others) to use the `hubspot` CLI to accomplish CRM tasks.
+Markdown skill files for AI agents (Claude Code, Cursor, Windsurf, and others) to use the `hubspot` CLI to accomplish CRM tasks. The `hubspot` agent CLI is distinct from `hs`, the `@hubspot/cli` developer CLI for building apps, themes, and modules.
 
 ---
 

--- a/bulk-operations/SKILL.md
+++ b/bulk-operations/SKILL.md
@@ -21,7 +21,7 @@ triggers:
 
 ## Source of truth
 
-`hubspot <command> --help` is authoritative. If anything in this file contradicts `--help`, trust `--help` and tell the user. Run `hubspot objects types` once at the start of a session to see what object types exist in this portal (standard + custom).
+This is the `hubspot` agent CLI; the `hs` developer CLI (`@hubspot/cli`) is a different tool and does not manage CRM data or workflows. `hubspot <command> --help` is authoritative. If anything in this file contradicts `--help`, trust `--help` and tell the user. Run `hubspot objects types` once at the start of a session to see what object types exist in this portal (standard + custom).
 
 ## Output shape
 

--- a/workflow-automation/SKILL.md
+++ b/workflow-automation/SKILL.md
@@ -73,7 +73,7 @@ hubspot workflows create --file workflow.json
 cat workflow.json | hubspot workflows create         # stdin also works
 ```
 
-Set `type` (`CONTACT_FLOW` or `PLATFORM_FLOW`), `flowType` (`WORKFLOW`), and `objectTypeId` (e.g. `0-1` for contacts) — all required on create. See `resources/workflow-json-reference.md` for the body shape and `resources/example-contact-flow.json` for the minimal template. **Easiest path: `get` an existing similar workflow as a starting template** rather than hand-writing the JSON. On a fresh portal with nothing to copy, build the steps once in the UI then `get` that flow — there is no CLI command to list action types (see the "No workflow to copy from?" note in `resources/workflow-json-reference.md`).
+Set `type` (`CONTACT_FLOW` or `PLATFORM_FLOW`), `flowType` (`WORKFLOW`), and `objectTypeId` (e.g. `0-1` for contacts) — all required on create. See `resources/workflow-json-reference.md` for the body shape and `resources/example-contact-flow.json` for the minimal template. **Easiest path: `get` an existing similar workflow as a starting template** rather than hand-writing the JSON.
 
 **Pitfall: `create --dry-run` does not validate the body.** It echoes the JSON back with `ok:true` and makes no API call — a green dry-run proves only that the input is well-formed JSON, not that it's a valid create (a body missing `type`/`flowType`/`objectTypeId`/`actions` still returns `ok:true`). The only real validation is the live `create`. By contrast, `update --dry-run` does reject a body missing required fields like `revisionId`.
 

--- a/workflow-automation/SKILL.md
+++ b/workflow-automation/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: workflow-automation
-description: List, inspect, create, update, and delete HubSpot workflows (v4 flows API) from the CLI.
+description: List, inspect, create, update, and delete HubSpot workflows (v4 flows API) from the `hubspot` agent CLI, not the `hs` developer CLI.
 triggers:
   - "workflow"
   - "automation"
@@ -10,14 +10,30 @@ triggers:
   - "duplicate workflow"
   - "update workflow"
   - "delete workflow"
+  - "create a workflow"
+  - "create a workflow with the hubspot cli"
+  - "build an automation"
+  - "does the cli support workflows"
 ---
+
+## Which CLI
+
+Two different HubSpot CLIs share a confusing resemblance — don't mix them up:
+
+- **`hubspot`** — the HubSpot **agent CLI** that this skill library targets. It manages CRM data and automation, and it **does** have native workflow commands: `hubspot workflows list|get|create|update|delete`.
+- **`hs`** — the HubSpot **developer CLI** (`@hubspot/cli`), for building dev projects: themes, modules, serverless functions, UI extensions, and private apps (`hs project`, `hs upload`, `hs create`). It does **not** create or manage workflow records.
+
+To create or manage a workflow, use `hubspot workflows ...` — not `hs`.
+
+If anything here ever drifts, `hubspot workflows --help` and `hs --help` are authoritative.
 
 ## Resources
 
 | File | When to use |
 |---|---|
-| `resources/workflow-json-reference.md` | Body shape for create/update — top-level fields, `enrollmentCriteria`, common action types, full-PUT pitfall |
-| `resources/example-contact-flow.json` | Minimal valid `CONTACT_FLOW` body for `hubspot workflows create --file` |
+| `resources/workflow-json-reference.md` | Body shape for create/update — the action graph, branching/convergence, enrollment, full-PUT pitfall |
+| `resources/example-contact-flow.json` | Minimal valid `CONTACT_FLOW` skeleton for `hubspot workflows create --file` |
+| `resources/example-branching-flow.json` | Illustrates branch convergence — two paths pointing `connection.nextActionId` at one shared downstream action |
 
 ## Source of truth
 
@@ -57,7 +73,9 @@ hubspot workflows create --file workflow.json
 cat workflow.json | hubspot workflows create         # stdin also works
 ```
 
-Set `type` to `CONTACT_FLOW` or `PLATFORM_FLOW`; for `PLATFORM_FLOW` include `objectTypeId`. See `resources/workflow-json-reference.md` for the body shape, and `resources/example-contact-flow.json` for a minimal template. **Easiest path: `get` an existing similar workflow as a starting template** rather than hand-writing the JSON.
+Set `type` (`CONTACT_FLOW` or `PLATFORM_FLOW`), `flowType` (`WORKFLOW`), and `objectTypeId` (e.g. `0-1` for contacts) — all required on create. See `resources/workflow-json-reference.md` for the body shape and `resources/example-contact-flow.json` for the minimal template. **Easiest path: `get` an existing similar workflow as a starting template** rather than hand-writing the JSON.
+
+**Branching and convergence.** A `LIST_BRANCH` action forks the path on filter criteria; each branch — and the `defaultBranch` — carries a `connection` to the action it continues to. Because connections target actions by `nextActionId`, **branches can converge**: point two branches at the same `actionId` and both paths continue to one shared action, no duplication. See the branching section of `resources/workflow-json-reference.md` and `resources/example-branching-flow.json`.
 
 ## 4. Update — full PUT, get-modify-put round-trip
 

--- a/workflow-automation/SKILL.md
+++ b/workflow-automation/SKILL.md
@@ -73,7 +73,7 @@ hubspot workflows create --file workflow.json
 cat workflow.json | hubspot workflows create         # stdin also works
 ```
 
-Set `type` (`CONTACT_FLOW` or `PLATFORM_FLOW`), `flowType` (`WORKFLOW`), and `objectTypeId` (e.g. `0-1` for contacts) — all required on create. See `resources/workflow-json-reference.md` for the body shape and `resources/example-contact-flow.json` for the minimal template. **Easiest path: `get` an existing similar workflow as a starting template** rather than hand-writing the JSON.
+Set `type` (`CONTACT_FLOW` or `PLATFORM_FLOW`), `flowType` (`WORKFLOW`), and `objectTypeId` (e.g. `0-1` for contacts) — all required on create. See `resources/workflow-json-reference.md` for the body shape and `resources/example-contact-flow.json` for the minimal template. **Easiest path: `get` an existing similar workflow as a starting template** rather than hand-writing the JSON. On a fresh portal with nothing to copy, build the steps once in the UI then `get` that flow — there is no CLI command to list action types (see the "No workflow to copy from?" note in `resources/workflow-json-reference.md`).
 
 **Pitfall: `create --dry-run` does not validate the body.** It echoes the JSON back with `ok:true` and makes no API call — a green dry-run proves only that the input is well-formed JSON, not that it's a valid create (a body missing `type`/`flowType`/`objectTypeId`/`actions` still returns `ok:true`). The only real validation is the live `create`. By contrast, `update --dry-run` does reject a body missing required fields like `revisionId`.
 

--- a/workflow-automation/SKILL.md
+++ b/workflow-automation/SKILL.md
@@ -75,6 +75,8 @@ cat workflow.json | hubspot workflows create         # stdin also works
 
 Set `type` (`CONTACT_FLOW` or `PLATFORM_FLOW`), `flowType` (`WORKFLOW`), and `objectTypeId` (e.g. `0-1` for contacts) — all required on create. See `resources/workflow-json-reference.md` for the body shape and `resources/example-contact-flow.json` for the minimal template. **Easiest path: `get` an existing similar workflow as a starting template** rather than hand-writing the JSON.
 
+**Pitfall: `create --dry-run` does not validate the body.** It echoes the JSON back with `ok:true` and makes no API call — a green dry-run proves only that the input is well-formed JSON, not that it's a valid create (a body missing `type`/`flowType`/`objectTypeId`/`actions` still returns `ok:true`). The only real validation is the live `create`. By contrast, `update --dry-run` does reject a body missing required fields like `revisionId`.
+
 **Branching and convergence.** A `LIST_BRANCH` action forks the path on filter criteria; each branch — and the `defaultBranch` — carries a `connection` to the action it continues to. Because connections target actions by `nextActionId`, **branches can converge**: point two branches at the same `actionId` and both paths continue to one shared action, no duplication. See the branching section of `resources/workflow-json-reference.md` and `resources/example-branching-flow.json`.
 
 ## 4. Update — full PUT, get-modify-put round-trip

--- a/workflow-automation/resources/example-branching-flow.json
+++ b/workflow-automation/resources/example-branching-flow.json
@@ -1,0 +1,46 @@
+{
+  "name": "Example Branching Flow — Two Paths Converging on One Action",
+  "description": "Demonstrates branch CONVERGENCE in the v4 graph: the matching branch and the default branch both set connection.nextActionId to action \"2\", so both paths continue to the same shared downstream action — no duplication needed. The branch's actionTypeId/actionTypeVersion/fields and the filter conditions are ILLUSTRATIVE placeholders; replace them with values copied from a real `hubspot workflows get` (as written, this body will not create). See workflow-json-reference.md.",
+  "type": "CONTACT_FLOW",
+  "flowType": "WORKFLOW",
+  "isEnabled": false,
+  "objectTypeId": "0-1",
+  "startActionId": "1",
+  "actions": [
+    {
+      "actionId": "1",
+      "type": "LIST_BRANCH",
+      "listBranches": [
+        {
+          "branchName": "Connected leads",
+          "connection": { "edgeType": "STANDARD", "nextActionId": "2" },
+          "filterBranch": {
+            "filterBranchType": "OR",
+            "filterBranchOperator": "OR",
+            "filterBranches": [],
+            "filters": [
+              {
+                "property": "hs_lead_status",
+                "operation": {
+                  "operationType": "ENUMERATION",
+                  "operator": "IS_ANY_OF",
+                  "values": ["CONNECTED"]
+                }
+              }
+            ]
+          }
+        }
+      ],
+      "defaultBranchName": "Everyone else",
+      "defaultBranch": { "edgeType": "STANDARD", "nextActionId": "2" }
+    },
+    {
+      "actionId": "2",
+      "type": "SINGLE_CONNECTION",
+      "actionTypeId": "<copy-from-a-real-get>",
+      "actionTypeVersion": 1,
+      "fields": {}
+    }
+  ],
+  "suppressionListIds": []
+}

--- a/workflow-automation/resources/example-contact-flow.json
+++ b/workflow-automation/resources/example-contact-flow.json
@@ -1,30 +1,10 @@
 {
-  "name": "Example Contact Flow — Set Lead Status on Lead Enrollment",
+  "name": "Example Contact Flow — Minimal Skeleton",
+  "description": "Smallest body that `hubspot workflows create` accepts. The structure here is verified against the v4 API; to add steps, copy real action objects from `hubspot workflows get <id>` rather than hand-writing them. See workflow-json-reference.md.",
   "type": "CONTACT_FLOW",
+  "flowType": "WORKFLOW",
   "isEnabled": false,
-  "enrollmentCriteria": {
-    "filterGroups": [
-      {
-        "filters": [
-          {
-            "property": "lifecyclestage",
-            "operation": {
-              "operationType": "ENUMERATION",
-              "operator": "IS_ANY_OF",
-              "values": ["lead"]
-            }
-          }
-        ]
-      }
-    ],
-    "type": "OR"
-  },
-  "actions": [
-    {
-      "type": "SET_CONTACT_PROPERTY",
-      "propertyName": "hs_lead_status",
-      "newValue": "IN_PROGRESS"
-    }
-  ],
+  "objectTypeId": "0-1",
+  "actions": [],
   "suppressionListIds": []
 }

--- a/workflow-automation/resources/workflow-json-reference.md
+++ b/workflow-automation/resources/workflow-json-reference.md
@@ -15,6 +15,8 @@ hubspot workflows get <id> > workflow.json                              # copy i
 
 A real `get` gives you exact `actionTypeId`, `actionTypeVersion`, and `fields` values for every action — the parts this reference deliberately does not invent.
 
+**No workflow to copy from?** A brand-new portal has nothing to `get`, and there is no CLI command (and no public endpoint) that lists the built-in action types and their `fields`. The automation platform keeps such a catalog internally, but the `hubspot` CLI only does flow CRUD and doesn't surface it. So the reliable bootstrap is one UI round-trip: build the step(s) you need once in the HubSpot UI (Automations → a throwaway flow with the Set property / Delay / Create task / branch actions you're after), then `hubspot workflows get <id>` on it and lift the exact `actionTypeId` / `actionTypeVersion` / `fields` from its `actions[]`. Seed every shape once, then reuse from there.
+
 ---
 
 ## Top-Level Fields

--- a/workflow-automation/resources/workflow-json-reference.md
+++ b/workflow-automation/resources/workflow-json-reference.md
@@ -1,24 +1,5 @@
 # Workflow JSON Reference
 
-This describes the body of a HubSpot automation flow as used by `hubspot workflows get`, `create`, and `update`. Those commands call the public `/automation/v4/flows` API and pass the JSON straight through, so this body **is** the v4 flow shape.
-
-> **What's verified here.** The structure below is grounded in HubSpot's public Automation V4 OpenAPI spec and the `hubspot` CLI's own acceptance test. What is **not** verified here is the exact `actionTypeId` / `fields` for each concrete action (a "set property" vs a "create task" step, etc.) — those are specific to each action type and version. Get them by copying a real action (next section), not from this doc.
-
-## Start from a real workflow
-
-The most reliable way to author a flow is to **`get` an existing one and modify it** — don't hand-write the JSON from scratch:
-
-```bash
-hubspot workflows list | jq -c 'select(.name | test("welcome"; "i"))'   # find a similar flow
-hubspot workflows get <id> > workflow.json                              # copy its real shape
-```
-
-A real `get` gives you exact `actionTypeId`, `actionTypeVersion`, and `fields` values for every action — the parts this reference deliberately does not invent.
-
-**No workflow to copy from?** A brand-new portal has nothing to `get`, and there is no CLI command (and no public endpoint) that lists the built-in action types and their `fields`. The automation platform keeps such a catalog internally, but the `hubspot` CLI only does flow CRUD and doesn't surface it. So the reliable bootstrap is one UI round-trip: build the step(s) you need once in the HubSpot UI (Automations → a throwaway flow with the Set property / Delay / Create task / branch actions you're after), then `hubspot workflows get <id>` on it and lift the exact `actionTypeId` / `actionTypeVersion` / `fields` from its `actions[]`. Seed every shape once, then reuse from there.
-
----
-
 ## Top-Level Fields
 
 | Field | Type | Writable | Notes |

--- a/workflow-automation/resources/workflow-json-reference.md
+++ b/workflow-automation/resources/workflow-json-reference.md
@@ -1,6 +1,19 @@
 # Workflow JSON Reference
 
-This document describes the structure of a HubSpot workflow (automation flow) JSON as returned by `hubspot workflows get <id>`. Use this as a reference when reading, editing, or creating workflow JSON files.
+This describes the body of a HubSpot automation flow as used by `hubspot workflows get`, `create`, and `update`. Those commands call the public `/automation/v4/flows` API and pass the JSON straight through, so this body **is** the v4 flow shape.
+
+> **What's verified here.** The structure below is grounded in HubSpot's public Automation V4 OpenAPI spec and the `hubspot` CLI's own acceptance test. What is **not** verified here is the exact `actionTypeId` / `fields` for each concrete action (a "set property" vs a "create task" step, etc.) — those are specific to each action type and version. Get them by copying a real action (next section), not from this doc.
+
+## Start from a real workflow
+
+The most reliable way to author a flow is to **`get` an existing one and modify it** — don't hand-write the JSON from scratch:
+
+```bash
+hubspot workflows list | jq -c 'select(.name | test("welcome"; "i"))'   # find a similar flow
+hubspot workflows get <id> > workflow.json                              # copy its real shape
+```
+
+A real `get` gives you exact `actionTypeId`, `actionTypeVersion`, and `fields` values for every action — the parts this reference deliberately does not invent.
 
 ---
 
@@ -8,154 +21,149 @@ This document describes the structure of a HubSpot workflow (automation flow) JS
 
 | Field | Type | Writable | Notes |
 |---|---|---|---|
-| `id` | string | **read-only** | Workflow ID assigned by HubSpot |
-| `name` | string | yes | Display name of the workflow |
+| `name` | string | yes | Display name |
+| `description` | string | yes | Optional free text |
 | `type` | string | yes | `CONTACT_FLOW` (contacts) or `PLATFORM_FLOW` (deal, company, ticket, custom object) |
-| `isEnabled` | boolean | yes | `true` activates the workflow; `false` for drafts and templates |
-| `objectTypeId` | string | yes | Object type the flow enrolls (e.g. `0-1` contacts, `0-2` companies, `0-3` deals). Required for `PLATFORM_FLOW` |
-| `revisionId` | string | required on update | Returned by `get`; the API uses it for optimistic concurrency on PUT |
-| `createdAt` | string | **read-only** | Stripped before request on create/update |
-| `updatedAt` | string | **read-only** | Stripped before request on create/update |
-| `dataSources` | array | **read-only** | Stripped before request on create/update |
-| `enrollmentCriteria` | object | yes | Defines which contacts/records enroll (see below) |
-| `actions` | array | yes | Ordered list of actions the workflow executes (see below) |
+| `flowType` | string | yes | `WORKFLOW` for a standard workflow. Required on create |
+| `objectTypeId` | string | yes | Object type the flow enrolls — `0-1` contacts, `0-2` companies, `0-3` deals. Set it for `CONTACT_FLOW` (`0-1`) as well as `PLATFORM_FLOW` |
+| `isEnabled` | boolean | yes | `true` activates the flow; `false` for drafts and templates |
+| `actions` | array | yes | The flow's actions, wired as a graph — see below |
+| `startActionId` | string | yes | `actionId` of the first action to run |
+| `enrollmentCriteria` | object | yes | Which records enroll — a typed object, see below |
 | `suppressionListIds` | array | yes | List IDs whose members are excluded from enrollment |
+| `revisionId` | string | required on update | Returned by `get`; the API uses it for optimistic concurrency on PUT |
+| `id` | string | **read-only** | Workflow ID assigned by HubSpot |
+| `createdAt` / `updatedAt` | string | **read-only** | Stripped before request on create/update |
+| `dataSources` | array | **read-only** | Stripped before request on create/update |
+| `crmObjectCreationStatus` | string | **read-only** | Must read `COMPLETE` before an update PUT is accepted (provisioned asynchronously after create) |
+| `nextAvailableActionId` | integer | **read-only** | Counter the API maintains for assigning new action ids |
 
-### `type` Values
+The v4 spec marks a few more fields required (`blockedDates`, `canEnrollFromSalesforce`, `customProperties`, `timeWindows`, …), but the API fills defaults for them — the minimal body below creates successfully without them.
 
-| Value | Enrolls |
-|---|---|
-| `CONTACT_FLOW` | Contact records |
-| `PLATFORM_FLOW` | Company, deal, ticket, or other object records |
+**Minimal valid create body** (verified against the CLI acceptance test):
+
+```json
+{
+  "name": "My flow",
+  "type": "CONTACT_FLOW",
+  "flowType": "WORKFLOW",
+  "isEnabled": false,
+  "objectTypeId": "0-1",
+  "actions": []
+}
+```
+
+See `resources/example-contact-flow.json`.
+
+---
+
+## `actions` — a graph, not an ordered list
+
+`actions` is a **flat array of action objects wired into a graph**, not a sequential to-do list. Execution begins at `startActionId` and follows each action's `connection` to the next:
+
+- Every action has a string **`actionId`**, unique within the flow.
+- Most actions carry a **`connection`** to the next action:
+
+  ```json
+  "connection": { "edgeType": "STANDARD", "nextActionId": "2" }
+  ```
+
+  `edgeType` is `STANDARD` (continue to the next action) or `GOTO` (jump to an action defined elsewhere in the graph). `nextActionId` is the `actionId` to run next.
+- An action with no `connection` is terminal — the path ends there.
+
+Array position does not define order; the `connection` / `nextActionId` edges do.
+
+### `SINGLE_CONNECTION` — a standard step
+
+The common action shape: do one thing, then continue to one next action.
+
+```json
+{
+  "actionId": "2",
+  "type": "SINGLE_CONNECTION",
+  "actionTypeId": "<copy-from-a-real-get>",
+  "actionTypeVersion": 1,
+  "fields": {},
+  "connection": { "edgeType": "STANDARD", "nextActionId": "3" }
+}
+```
+
+`actionTypeId` + `actionTypeVersion` + `fields` are what make a step a "set property", "create task", "send email", and so on. Their exact values vary per action type and version — **copy them from a real `hubspot workflows get`** rather than guessing. Omit `connection` on the final step.
+
+### `LIST_BRANCH` — branch on a condition
+
+Forks the path on filter criteria. Each branch carries its own `connection` to whatever action it continues to:
+
+```json
+{
+  "actionId": "1",
+  "type": "LIST_BRANCH",
+  "listBranches": [
+    {
+      "branchName": "Connected leads",
+      "connection": { "edgeType": "STANDARD", "nextActionId": "2" },
+      "filterBranch": {
+        "filterBranchType": "OR",
+        "filterBranchOperator": "OR",
+        "filterBranches": [],
+        "filters": []
+      }
+    }
+  ],
+  "defaultBranchName": "Everyone else",
+  "defaultBranch": { "edgeType": "STANDARD", "nextActionId": "2" }
+}
+```
+
+- `listBranches[]` — one entry per condition; each has its own `connection` and `filterBranch`. The `filterBranch.filters[]` array holds the property conditions — copy those from a real `get`.
+- `defaultBranch` — the fall-through `connection` for records matching no branch.
+- A record travels **exactly one** branch.
+
+(Other branch action types exist, such as `AB_TEST_BRANCH`; `get` a real one to see its shape.)
+
+### Branching and convergence
+
+Because branches connect to downstream actions by `nextActionId`, **multiple branches can converge on the same action** — just point their `connection.nextActionId` at the same `actionId`. In the snippet above, the matching branch and `defaultBranch` both target action `"2"`, so both paths continue to one shared step. There is no duplication and no double-execution: the record runs `"2"` once, on whichever path it took. An `edgeType: "GOTO"` connection lets a branch jump to an action defined earlier in the graph (e.g. to rejoin a shared tail). See `resources/example-branching-flow.json`.
 
 ---
 
 ## `enrollmentCriteria`
 
-Controls which records enter the workflow. Uses a nested filter group structure with AND/OR logic.
+Controls which records enter the flow. It is **typed** — a `type` discriminator selects the shape. The common one is `LIST_BASED` (enroll records matching a filter):
 
 ```json
 "enrollmentCriteria": {
-  "filterGroups": [
-    {
-      "filters": [
-        {
-          "property": "lifecyclestage",
-          "operation": {
-            "operationType": "ENUMERATION",
-            "operator": "IS_ANY_OF",
-            "values": ["lead"]
-          }
-        }
-      ]
-    }
-  ],
-  "type": "OR"
+  "type": "LIST_BASED",
+  "listFilterBranch": {
+    "filterBranchType": "OR",
+    "filterBranchOperator": "OR",
+    "filterBranches": [],
+    "filters": []
+  },
+  "shouldReEnroll": false,
+  "unEnrollObjectsNotMeetingCriteria": false,
+  "reEnrollmentTriggersFilterBranches": []
 }
 ```
 
-- `filterGroups` — array of groups; records matching **any** group are enrolled (OR between groups)
-- `filters` within a group — records must match **all** filters to satisfy that group (AND within a group)
-- `operation.operationType` — common values: `ENUMERATION`, `STRING`, `NUMBER`, `BOOL`
-- `operation.operator` — common values: `IS_ANY_OF`, `IS_NONE_OF`, `EQ`, `NEQ`, `GT`, `LT`, `HAS_PROPERTY`, `NOT_HAS_PROPERTY`
+The other `type` values are `EVENT_BASED`, `MANUAL`, and `DATASET`. As with actions, copy a real `enrollmentCriteria` from `hubspot workflows get` to get the exact filter shape.
 
----
+## Filter branches
 
-## `actions` Array
-
-An ordered array of action objects. Each action has at minimum a `type` field.
-
-### Common Action Types
-
-#### `SET_CONTACT_PROPERTY`
-Sets a property value on the enrolled contact.
-
-```json
-{
-  "type": "SET_CONTACT_PROPERTY",
-  "propertyName": "hs_lead_status",
-  "newValue": "IN_PROGRESS"
-}
-```
-
-#### `SEND_EMAIL`
-Sends a marketing email. Requires the email ID from HubSpot's email tool.
-
-```json
-{
-  "type": "SEND_EMAIL",
-  "emailId": 12345
-}
-```
-
-#### `CREATE_TASK`
-Creates a CRM task assigned to the contact owner.
-
-```json
-{
-  "type": "CREATE_TASK",
-  "subject": "Follow up with lead",
-  "taskType": "CALL",
-  "dueDate": {
-    "delayMillis": 86400000
-  }
-}
-```
-
-#### `DELAY`
-Pauses execution for a fixed duration before the next action.
-
-```json
-{
-  "type": "DELAY",
-  "delayMillis": 86400000
-}
-```
-
-`delayMillis` is milliseconds. Common values: `3600000` (1 hour), `86400000` (1 day), `604800000` (7 days).
-
-#### `BRANCH`
-Forks the workflow based on a condition. Each branch has its own `actions` array.
-
-```json
-{
-  "type": "BRANCH",
-  "filterBranches": [
-    {
-      "filterBranchType": "OR",
-      "filters": [
-        {
-          "property": "hs_lead_status",
-          "operation": {
-            "operationType": "ENUMERATION",
-            "operator": "IS_ANY_OF",
-            "values": ["CONNECTED"]
-          }
-        }
-      ],
-      "actions": []
-    }
-  ],
-  "defaultBranchActions": []
-}
-```
-
----
+Both branch conditions and list-based enrollment use a **filter branch** object: `filterBranchType` (`OR` / `AND` / …), `filterBranchOperator`, a nested `filterBranches[]` array, and a `filters[]` array of property conditions. The exact `filters[]` item shape (property name, operator, values) is best taken verbatim from a real flow.
 
 ## `suppressionListIds`
 
-An array of HubSpot list IDs. Contacts on any of these lists will not enroll even if they match `enrollmentCriteria`.
-
-```json
-"suppressionListIds": [101, 202]
-```
-
-Use an empty array `[]` if no suppression lists are needed.
+An array of HubSpot list IDs. Records on any of these lists will not enroll even if they match `enrollmentCriteria`. Use `[]` if none are needed.
 
 ---
 
-## Key Rules
+## Update — full PUT, get-modify-put round-trip
 
-See `SKILL.md` for the authoritative command patterns. One non-obvious consequence worth noting here:
+Update is a **full replace**, not a patch:
 
-**Partial edits silently corrupt workflows.** Because update is a full PUT, sending only an `actions` array without `enrollmentCriteria` will clear the enrollment trigger entirely — no error, no warning. Always start from the full `get` response.
+- Include `revisionId` (from `get`) — the API uses it for optimistic concurrency.
+- Read-only fields (`createdAt`, `updatedAt`, `dataSources`) are stripped automatically by the CLI.
+- `crmObjectCreationStatus` must read `COMPLETE` before a PUT is accepted; right after create it may still be provisioning, so re-`get` until it does.
+
+**Pitfall — partial bodies silently drop fields.** Because update is a full PUT, sending only an `actions` array without `enrollmentCriteria` clears the enrollment trigger entirely — no error, no warning. Always start from the full `get` response.


### PR DESCRIPTION
## What

Refines the existing `workflow-automation` skill and disambiguates the `hubspot` agent CLI from the `hs` developer CLI across the skill library (README, `bulk-operations`, `workflow-automation`). Corrects the workflow JSON reference against the real `AutomationFlowApi` shape and adds a worked branch-convergence example.

## Why

Agents kept conflating the two HubSpot CLIs — `hubspot` (the agent CLI, which *does* have `workflows list|get|create|update|delete`) and `hs` (the `@hubspot/cli` developer CLI for projects/themes/modules, which does not touch workflow records). That ambiguity led agents to wrongly conclude the CLI couldn't manage workflows. This adds an explicit "Which CLI" section plus disambiguation in the README and bulk-operations skill.

The workflow JSON reference and worked examples are grounded against the real `AutomationFlowApi` shape rather than guessed — notably that branches **can converge** (two branches sharing a `connection.nextActionId` continue to one shared action, no duplication), and that the `enrollmentCriteria` discriminator is `DATASET` on the wire (not `DATASET_BASED`). A new `example-branching-flow.json` shows the convergence pattern.
