### PR TITLE
Publish agent CLI skills from hub-cli

### DIFF
--- a/audience-targeting/SKILL.md
+++ b/audience-targeting/SKILL.md
@@ -108,9 +108,16 @@ jq -c '{id}' segments/opted_in_leads.jsonl \
 
 Destructive ops on a saved segment follow the dry-run → digest → confirm flow in `bulk-operations/SKILL.md`.
 
+## Save as a HubSpot list or view
+
+A JSONL segment is portable, but you can also persist an audience in HubSpot:
+
+- **List** — `hubspot segments create` saves a list; `segments get` / `list` inspect it; `segments members-list` reads members; `segments members-add` / `members-remove` manage membership. Use `segments update-filters` to set a dynamic list's filter criteria.
+- **View** — `hubspot views create --type <t> --name "..." --columns a,b [--filters-file filters.json] [--sort prop:asc]` saves a filter set as a reusable object view; `views list` / `get` / `update` / `replace-field` / `delete` manage it.
+- **Size it first** — `hubspot objects count --type contacts --filter "..."` returns `{"object_type":"contacts","total":N}` without paging, so you can size an audience before saving or exporting it.
+
 ## Known limits
 
-- No Lists API surface. Can't save as a HubSpot list or filter by list membership.
 - `~` is token-match, not substring. No regex operator.
 - `properties get` does not return enum options — discover via `objects list` + `jq`.
 - `associations list` has no batch `--from`. Loop to gather IDs, batch the downstream `objects get`.

--- a/bulk-operations/SKILL.md
+++ b/bulk-operations/SKILL.md
@@ -74,7 +74,7 @@ A single `hubspot objects get` reads up to ~100 IDs per call via the batch endpo
 
 ## Bulk flow: paginate first, then reshape, then write
 
-When operating on all records of a type (or all matches of a filter), **always start with `pagination-loop.sh`** — never run a bare `list` or `search` to "check how many there are." A bare call returns at most 100 records and you will have to re-fetch them anyway.
+When operating on all records of a type (or all matches of a filter), **always start with `pagination-loop.sh`** — never run a bare `list` or `search` to "check how many there are." A bare call returns at most 100 records and you will have to re-fetch them anyway. To size the job first, use `hubspot objects count --type <t> [--filter "..."]`, which returns the total matching count (e.g. `{"object_type":"contacts","total":42}`) without paging.
 
 The canonical bulk pattern is:
 
@@ -167,6 +167,8 @@ hubspot history --since 7d --kind MetadataDestroy # schema deletes
 
 `history` does not currently restore records — it's an audit log. If you deleted something by mistake, capture the history line and tell the user to restore via the UI.
 
+For CRM property *source* history (who or what changed a property — `WORKFLOW`, `INTEGRATION`, `IMPORT`, `CRM_UI`), use `hubspot objects history --type <t> --properties <p>`. It flattens each property's version history into one row per change; UI-driven (`CRM_UI`) changes are excluded by default (`--include-ui` to keep them). Add `--id <recordId>` to read one record, or omit it to scan a page. This is separate from the local `hubspot history` audit log above — use it to investigate why a property changed after a bulk op.
+
 ## Upsert beats search-then-create
 
 For "create if missing, update if present" (the enrichment pattern), use `upsert` — one CLI call per record, no race condition:
@@ -206,4 +208,4 @@ hubspot objects search --type contacts --filter "!email" \
 
 - Some destructive operations may be blocked under user-OAuth (browser login); set `HUBSPOT_ACCESS_TOKEN` (private app token) when running deletes if the CLI returns a permission error.
 - `hubspot owners list` returns CRM users; there is no `teams` object. For team-level operations, group by `hubspot_owner_id` client-side.
-- No Lists API, no sequences/cadences API in the current CLI surface.
+- `hubspot segments` provides CRM lists: `list`, `get`, `create`, `update` (metadata), `update-filters`, `delete`, `restore`, and `members-list` / `members-add` / `members-remove`. No sequences/cadences API in the current CLI surface.

--- a/bulk-operations/resources/json-patterns.md
+++ b/bulk-operations/resources/json-patterns.md
@@ -51,8 +51,9 @@ hubspot objects search --type contacts --filter "company~acme" \
 
 ```bash
 # Companies with revenue > 1M
+# Numeric CRM props can be null OR "" (empty string) when blank; guard the empty string too before tonumber.
 hubspot objects list --type companies \
-| jq -c 'select((.properties.annualrevenue // "0") | tonumber > 1000000)'
+| jq -c 'select(.properties.annualrevenue != null and .properties.annualrevenue != "" and ((.properties.annualrevenue | tonumber) > 1000000))'
 
 # Exclude obvious junk emails (server-side ~ is whole-token only)
 hubspot objects list --type contacts \

--- a/customer-retention/SKILL.md
+++ b/customer-retention/SKILL.md
@@ -47,6 +47,8 @@ hubspot objects search --type contacts \
 
 For more signals (email opt-out, stale tickets, no open deals) see `resources/customer-health-signals.md`. For >100 hits, use the pagination loop from `bulk-operations`.
 
+To audit *why* a customer churned or moved stage — which workflow, integration, import, or UI edit last changed `lifecyclestage` — use `hubspot objects history --type contacts --properties lifecyclestage [--id <recordId>] [--include-ui]`. It flattens each property's source history into one row per change.
+
 ## 2 — Flag at-risk subscriptions
 
 `subscriptions` is a standard object (`hubspot objects types` confirms). Enum values for `hs_subscription_status` are portal-specific — verify before filtering, then plug the exact value in:
@@ -114,5 +116,5 @@ One CLI call for the search, one for the create, then N for associations — no 
 ## Known gaps
 
 - No native churn-score / health-score property — track via a custom property.
-- No Lists API, no sequences/cadences API — re-engagement enrollment is not CLI-available.
+- `hubspot segments` provides CRM lists for re-engagement cohorts — `segments members-list` pulls a list's members, and `segments create` / `update-filters` save an at-risk audience as a reusable list. Re-engagement enrollment can be built as a workflow via `hubspot workflows create` / `update` (see `workflow-automation/SKILL.md`). No sequences/cadences API in the current CLI surface.
 - `hubspot associations create` does not batch — one CLI call per pair.

--- a/quote-to-cash/SKILL.md
+++ b/quote-to-cash/SKILL.md
@@ -118,7 +118,7 @@ hubspot objects search --type subscriptions \
 # Sum MRR across active subs
 hubspot objects search --type subscriptions \
   --filter "hs_subscription_status=<active-value>" --format json \
-  | jq '[.data[].properties.hs_mrr | select(. != null) | tonumber] | add'
+  | jq '[.data[].properties.hs_mrr | select(. != null and . != "") | tonumber] | add // 0'
 ```
 
 ## Known constraints

--- a/sales-reporting/SKILL.md
+++ b/sales-reporting/SKILL.md
@@ -21,10 +21,11 @@ triggers:
 ## Property and output shape notes
 
 - All CRM property values come back as **strings** in JSONL — booleans included. `hs_is_closed_won` is returned as `"true"`/`"false"` (string); `amount` is a numeric string. Use `tonumber` for arithmetic; compare booleans as strings (`== "true"`) when filtering client-side.
+- **Numeric properties can be `null` *or* an empty string (`""`)** when unset/blank. `tonumber` aborts on `""`. Always guard with `select(. != null and . != "") | tonumber`.
 - In `--filter` expressions, `hs_is_closed_won=true` and `hs_is_closed!=true` work — the API parses the value.
 - `--properties` returns the standard nested shape: `{"id":"123","properties":{"amount":"5000","dealname":"..."}}`. Reference fields as `.properties.amount` in jq.
-- Stage IDs in `dealstage` are portal-specific. Map them with `hubspot pipelines stages --type deals --pipeline <id>`.
-- `hubspot_owner_id` is a numeric string. Resolve to a name with `hubspot owners list` (fields: `id`, `firstName`, `lastName`, `email`).
+- Stage IDs in `dealstage` are portal-specific. Map them with `hubspot pipelines stages --type deals --pipeline <id>`. **`hubspot pipelines` is app-token-only** — see Auth section; it 403s under user OAuth.
+- `hubspot_owner_id` is a numeric string. Resolve to a name with `hubspot owners list` (fields: `id`, `firstName`, `lastName`, `email`). **`hubspot owners list` is app-token-only** — see Auth section; it 403s under user oauth.
 
 ## 1. Daily briefing
 
@@ -53,7 +54,7 @@ hubspot objects search --type deals \
 **Open-pipeline summary line:**
 ```bash
 hubspot objects search --type deals --filter "hs_is_closed!=true" --properties amount \
-| jq -rs '{count: length, value: ([.[].properties.amount | select(. != null) | tonumber] | add // 0 | round)}
+| jq -rs '{count: length, value: ([.[].properties.amount | select(. != null and . != "") | tonumber] | add // 0 | round)}
           | "Open pipeline: \(.count) deals, $\(.value)"'
 ```
 
@@ -66,7 +67,7 @@ hubspot objects search --type deals --filter "hs_is_closed!=true" \
 | jq -rs '
     group_by(.properties.dealstage)
     | map({stage: .[0].properties.dealstage, count: length,
-           total: ([.[].properties.amount | select(. != null) | tonumber] | add // 0 | round)})
+           total: ([.[].properties.amount | select(. != null and . != "") | tonumber] | add // 0 | round)})
     | sort_by(-.total) | .[] | "\(.stage)\tcount: \(.count)\tvalue: $\(.total)"' \
 | column -t -s$'\t'
 ```
@@ -78,13 +79,14 @@ hubspot objects search --type deals --filter "hs_is_closed!=true" \
 | jq -rs '
     group_by(.properties.hubspot_owner_id)
     | map({owner: .[0].properties.hubspot_owner_id, count: length,
-           total: ([.[].properties.amount | select(. != null) | tonumber] | add // 0 | round)})
+           total: ([.[].properties.amount | select(. != null and . != "") | tonumber] | add // 0 | round)})
     | sort_by(-.total) | .[] | "owner \(.owner)\tdeals: \(.count)\tvalue: $\(.total)"' \
 | column -t -s$'\t'
 ```
 
-To label owner IDs with names, dump the owners file once and join:
+To label owner IDs with names, dump the owners file once and join. This needs a service key — see Known limitations:
 ```bash
+export HUBSPOT_ACCESS_TOKEN=<service-key>
 hubspot owners list | jq -r '"\(.id)\t\(.firstName) \(.lastName) <\(.email)>"' > /tmp/owners.tsv
 ```
 
@@ -114,7 +116,7 @@ hubspot objects search --type deals \
            total: length,
            won: ([.[] | select(.properties.hs_is_closed_won == "true")] | length),
            won_value: ([.[] | select(.properties.hs_is_closed_won == "true")
-                       | .properties.amount | select(. != null) | tonumber] | add // 0 | round)})
+                       | .properties.amount | select(. != null and . != "") | tonumber] | add // 0 | round)})
     | map(. + {win_rate: ((.won / .total * 100) | round)})
     | sort_by(-.won_value)
     | .[] | "owner \(.owner)\twon: \(.won)/\(.total)\trate: \(.win_rate)%\twon: $\(.won_value)"' \
@@ -129,7 +131,7 @@ hubspot objects search --type deals \
 | jq -rs '
     group_by(.properties.closedate[0:7])
     | map({month: .[0].properties.closedate[0:7], count: length,
-           revenue: ([.[].properties.amount | select(. != null) | tonumber] | add // 0 | round)})
+           revenue: ([.[].properties.amount | select(. != null and . != "") | tonumber] | add // 0 | round)})
     | sort_by(.month) | .[] | "\(.month)\tdeals: \(.count)\trevenue: $\(.revenue)"' \
 | column -t -s$'\t'
 ```
@@ -138,3 +140,5 @@ hubspot objects search --type deals \
 
 - `hubspot pipelines stages` does not expose stage probability — won/lost stages can't be auto-identified from the stages list. Use `hs_is_closed_won` on deals instead.
 - No team object — group by `hubspot_owner_id` and resolve names from `hubspot owners list` client-side.
+- `hubspot owners list` and `hubspot pipelines` are app-token-only and 403 under user OAuth. Keep raw IDs + warn; do not fail the report.
+- Numeric CRM properties can be `null` or `""`; always guard `tonumber` with `select(. != null and . != "")`.

--- a/workflow-automation/SKILL.md
+++ b/workflow-automation/SKILL.md
@@ -39,6 +39,15 @@ If anything here ever drifts, `hubspot workflows --help` and `hs --help` are aut
 
 `hubspot workflows --help` lists five subcommands: `list`, `get`, `create`, `update`, `delete`. There is **no `search`** — finding by name is `list | jq`. For JSONL piping, pagination, and destructive dry-run/digest/confirm patterns, this skill builds on `bulk-operations/SKILL.md` — re-read that first.
 
+## Auth — service key required
+
+**Every `hubspot workflows` command requires `HUBSPOT_ACCESS_TOKEN` (a service key).** None of them work under `hubspot auth login` (user OAuth) — the CLI rejects them up front with `This endpoint does not support user-level OAuth tokens`. The `automation` scope the v4 flows API needs is not available to the CLI's user-level OAuth app, so set a service key before running anything in this skill:
+
+```bash
+export HUBSPOT_ACCESS_TOKEN=<service-key>   # create at Settings → Integrations → Service keys
+hubspot workflows list
+```
+
 ## 1. List + find by name
 
 ```bash
@@ -114,5 +123,5 @@ The dry-run output includes an `apply_command_hint` — copy the exact confirm s
 ## Known limitations
 
 - No `hubspot workflows search` — `list | jq` is the workaround.
-- No Lists API in the CLI — list-membership enrollment triggers must be wired up in the UI.
+- `hubspot segments` provides CRM lists (`list`, `get`, `create`, `update`, `update-filters`, `delete`, `restore`, `members-list` / `members-add` / `members-remove`). List-membership enrollment triggers are part of the workflow body (`enrollmentCriteria`), so configure them through `hubspot workflows create` / `update` — get the list ID with `hubspot segments list` / `get` and copy the `enrollmentCriteria` shape from a real `workflows get` (see `resources/workflow-json-reference.md`). No UI step required.
 - No sequences/cadences API. `dataSources` is read-only — cannot be rewired via update.


### PR DESCRIPTION
Automated publish of agent CLI skills co-located in hub-cli.

Updated files:
- audience-targeting/SKILL.md
- bulk-operations/SKILL.md
- bulk-operations/resources/json-patterns.md
- customer-retention/SKILL.md
- quote-to-cash/SKILL.md
- sales-reporting/SKILL.md
- workflow-automation/SKILL.md
